### PR TITLE
Clarify health endpoint semantics in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,44 @@ Open:
 
 ---
 
+## Health Endpoint
+
+```
+GET /health
+```
+
+Returns a JSON response indicating that the server process is running:
+
+```json
+{
+  "status": "ok",
+  "uptime": 1234.56
+}
+```
+
+**This is a liveness check**, not a readiness check. It confirms that the
+Node.js process is alive and can accept HTTP connections. It does **not**
+verify the availability of downstream dependencies such as Redis, Groq,
+or Gemini.
+
+**Liveness vs readiness:**
+
+| Check      | What it answers                                      | This endpoint |
+|------------|------------------------------------------------------|---------------|
+| Liveness   | Is the process running and responding to HTTP?       | Yes           |
+| Readiness  | Are downstream dependencies (Redis, providers) healthy? | No         |
+
+Readiness checks for Redis connectivity and provider health are not
+currently exposed through a dedicated endpoint. Provider health is
+tracked internally by the routing layer (`metricsStore.js`) and is
+visible through the authenticated `GET /admin/metrics` endpoint.
+
+If you are configuring health checks for a deployment platform
+(e.g. Koyeb, Railway, Kubernetes), use `/health` as the liveness
+probe. Do not rely on it to gate traffic readiness.
+
+---
+
 ## Deployment - Railway
 
 1. Create a new Railway project

--- a/src/server.js
+++ b/src/server.js
@@ -199,6 +199,8 @@ function createApp(overrides = {}) {
     return res.sendFile(path.join(publicDir, "admin.html"));
   });
 
+  // Liveness check only — confirms the process is running.
+  // Does not verify downstream dependencies (Redis, providers).
   app.get("/health", (req, res) => {
     return res.json({
       status: "ok",


### PR DESCRIPTION
## Summary

- Document that `GET /health` is a **liveness check only** — it confirms the Node.js process is running but does not verify Redis, Groq, or Gemini availability
- Add a liveness vs readiness comparison table to the README
- Note that provider health is available via the authenticated `GET /admin/metrics` endpoint
- Add an inline code comment in `server.js` for clarity
- All existing tests pass — no runtime behavior changes

Closes #13

## Test plan

- [x] `npm test` passes (17/17 tests)
- [x] Health endpoint documentation is clear and consistent between README and code
- [x] Liveness vs readiness distinction is explained
- [x] No runtime changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)