### PR TITLE
[DOCS] Add Anthropic provider to architecture overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ restarts when Redis is available.
 src/
 |-- providers/
 |   |-- groq.js              # Provider adapter - isolates Groq HTTP details
+|   |-- anthropic.js         # Anthropic Claude adapter
 |-- server.js                # Orchestration - request pipeline and endpoint wiring
 |-- router.js                # Route decision + health-aware model selection
 |-- embeddingRouter.js       # Intent detection - embeddings + LLM fallback


### PR DESCRIPTION
Closes https://github.com/cp50/ai-gateway/issues/18

This pull request updates the README’s architecture section to accurately reflect the current provider adapters available in the repository. The Anthropic provider adapter was recently merged, and this change ensures the documentation is consistent with the codebase. This update improves clarity for developers looking to understand the project’s structure and available integrations.